### PR TITLE
feat: Enhance tracing for distributed setups

### DIFF
--- a/modules/caddyhttp/tracing/module.go
+++ b/modules/caddyhttp/tracing/module.go
@@ -25,7 +25,8 @@ func init() {
 type Tracing struct {
 	// SpanName is a span name. It should follow the naming guidelines here:
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span
-	SpanName string `json:"span"`
+	SpanName                 string `json:"span"`
+	InjectServerTimingHeader bool   `json:"injectServerTimingHeader"`
 
 	// otel implements opentelemetry related logic.
 	otel openTelemetryWrapper
@@ -46,7 +47,7 @@ func (ot *Tracing) Provision(ctx caddy.Context) error {
 	ot.logger = ctx.Logger()
 
 	var err error
-	ot.otel, err = newOpenTelemetryWrapper(ctx, ot.SpanName)
+	ot.otel, err = newOpenTelemetryWrapper(ctx, ot.SpanName, ot.InjectServerTimingHeader)
 
 	return err
 }

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -88,11 +88,15 @@ func (ot *openTelemetryWrapper) serveHTTP(w http.ResponseWriter, r *http.Request
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.IsValid() {
 		traceID := spanCtx.TraceID().String()
+		spanID := spanCtx.SpanID().String()
 		// Add a trace_id placeholder, accessible via `{http.vars.trace_id}`.
 		caddyhttp.SetVar(ctx, "trace_id", traceID)
+		// Add a span_id placeholder, accessible via `{http.vars.span_id}`.
+		caddyhttp.SetVar(ctx, "span_ud", spanID)
 		// Add the trace id to the log fields for the request.
 		if extra, ok := ctx.Value(caddyhttp.ExtraLogFieldsCtxKey).(*caddyhttp.ExtraLogFields); ok {
 			extra.Add(zap.String("traceID", traceID))
+			extra.Add(zap.String("spanID", spanID))
 		}
 	}
 	next := ctx.Value(nextCallCtxKey).(*nextCall)

--- a/modules/caddyhttp/tracing/tracer.go
+++ b/modules/caddyhttp/tracing/tracer.go
@@ -92,7 +92,7 @@ func (ot *openTelemetryWrapper) serveHTTP(w http.ResponseWriter, r *http.Request
 		// Add a trace_id placeholder, accessible via `{http.vars.trace_id}`.
 		caddyhttp.SetVar(ctx, "trace_id", traceID)
 		// Add a span_id placeholder, accessible via `{http.vars.span_id}`.
-		caddyhttp.SetVar(ctx, "span_ud", spanID)
+		caddyhttp.SetVar(ctx, "span_id", spanID)
 		// Add the trace id to the log fields for the request.
 		if extra, ok := ctx.Value(caddyhttp.ExtraLogFieldsCtxKey).(*caddyhttp.ExtraLogFields); ok {
 			extra.Add(zap.String("traceID", traceID))

--- a/modules/caddyhttp/tracing/tracer_test.go
+++ b/modules/caddyhttp/tracing/tracer_test.go
@@ -14,9 +14,7 @@ func TestOpenTelemetryWrapper_newOpenTelemetryWrapper(t *testing.T) {
 	var otw openTelemetryWrapper
 	var err error
 
-	if otw, err = newOpenTelemetryWrapper(ctx,
-		"",
-	); err != nil {
+	if otw, err = newOpenTelemetryWrapper(ctx, "", false); err != nil {
 		t.Errorf("newOpenTelemetryWrapper() error = %v", err)
 		t.FailNow()
 	}


### PR DESCRIPTION
This PR enhances the opentelemetry instrumentation for caddy by:
* creating client spans for reverse proxy request to fix servicegraph calculations
* injecting, conditionally, a server-timing header to propagate the traceparent down to the caller